### PR TITLE
Fix a typo in CategoryEnumTest

### DIFF
--- a/test/tests/CategoryEnumTest.php
+++ b/test/tests/CategoryEnumTest.php
@@ -41,7 +41,7 @@ final class CategoryEnumTest extends TestCase
         );
     }
 
-    private static function inizialize(): void {}
+    private static function initialize(): void {}
     public function testEnumType(): void
     {
         $type = self::$categoryClass->getBackingType();


### PR DESCRIPTION
It was `function inizialize()`